### PR TITLE
feat: useScrolledPastThreshold 커스텀 훅

### DIFF
--- a/frontend/src/common/components/header/index.jsx
+++ b/frontend/src/common/components/header/index.jsx
@@ -1,15 +1,15 @@
 import { Link, useNavigate } from "react-router-dom";
-import { useState, useEffect } from "react";
+import { useState } from "react";
 
 import useAuthStore from "@/stores/useAuthStore";
 import useModalStore from "@/stores/useModalStore";
+import useScrolledPastThreshold from "@/hooks/useScrolledPastThreshold";
 
 import HeaderActionMenu from "./HeaderActionMenu";
 import Button from "../button";
 import UserProfile from "../user/UserProfile";
 import { LogoLabel, Logo } from "@/static/svg";
 
-import { throttle } from "@/common/utils";
 import { ROLE } from "@/common/constants";
 
 const Header = () => {
@@ -19,24 +19,9 @@ const Header = () => {
   const { role, picture, nickname } = userInfo;
 
   const { openModal } = useModalStore();
+  const { isScrollTop } = useScrolledPastThreshold();
 
   const [isActionMenuVisible, setIsActionMenuVisible] = useState(false);
-  const [isScrollTop, setIsScrollTop] = useState(true);
-
-  useEffect(() => {
-    document.addEventListener("scroll", throttledHandleScroll);
-    return () => {
-      document.removeEventListener("scroll", throttledHandleScroll);
-    };
-  }, [isScrollTop]);
-
-  const throttledHandleScroll = throttle(() => {
-    if (window.scrollY > 30) {
-      setIsScrollTop(false);
-    } else if (window.scrollY <= 30) {
-      setIsScrollTop(true);
-    }
-  }, 50);
 
   // 로그인 모달
   const handleOpenLoginModal = () => openModal("login");

--- a/frontend/src/hooks/useScrolledPastThreshold.js
+++ b/frontend/src/hooks/useScrolledPastThreshold.js
@@ -1,0 +1,30 @@
+import { useState, useEffect } from "react";
+
+import { throttle } from "@/common/utils";
+
+/**
+ * 스크롤이 thresholdY 값을 지났는지 확인하는 hook
+ * 스크롤 최상단은 0부터 시작함
+ */
+function useScrolledPastThreshold(thresholdY = 100, delay = 50) {
+  const [isScrollTop, setIsScrollTop] = useState(true);
+
+  useEffect(() => {
+    document.addEventListener("scroll", throttledHandleScroll);
+    return () => {
+      document.removeEventListener("scroll", throttledHandleScroll);
+    };
+  }, [isScrollTop]);
+
+  const throttledHandleScroll = throttle(() => {
+    if (window.scrollY > 30) {
+      setIsScrollTop(false);
+    } else if (window.scrollY <= 30) {
+      setIsScrollTop(true);
+    }
+  }, 50);
+
+  return isScrollTop;
+}
+
+export default useScrolledPastThreshold;


### PR DESCRIPTION
## ✏️ 요약

```js
/**
 * 스크롤이 thresholdY 값을 지났는지 확인하는 hook
 * 스크롤 최상단은 0부터 시작함
 */
function useScrolledPastThreshold(thresholdY = 100, delay = 50) {
  const [isScrollTop, setIsScrollTop] = useState(true);

  useEffect(() => {
    document.addEventListener("scroll", throttledHandleScroll);
    return () => {
      document.removeEventListener("scroll", throttledHandleScroll);
    };
  }, [isScrollTop]);

  const throttledHandleScroll = throttle(() => {
    if (window.scrollY > 30) {
      setIsScrollTop(false);
    } else if (window.scrollY <= 30) {
      setIsScrollTop(true);
    }
  }, 50);

  return isScrollTop;
}

export default useScrolledPastThreshold;
```

## ✨ 변경 사항

- Header 컴포넌트에 있던 로직 hook으로 분리

