### PR TITLE
fix:JwtAccessToken 예외처리 상태코드 에러 수정 #24

### DIFF
--- a/backend/src/main/java/io/linkloud/api/global/security/auth/jwt/filter/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/io/linkloud/api/global/security/auth/jwt/filter/JwtAuthenticationFilter.java
@@ -71,9 +71,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
                 log.info("Security Context 에 '{}' 인증 정보를 저장했습니다, uri: {}", authentication.getName(), requestURI);
             }
-        } catch (JwtException e) {
-            log.error("JWT parsing error: {}", e.getMessage());
-            response.setStatus(AuthExceptionCode.USER_UNAUTHORIZED.getStatus());
+        } catch (CustomException e) {
+            log.error("JWT error: {}", e.getMessage());
+            response.setStatus(e.getExceptionCode().getStatus());
             return;
         }
         log.info("JWT 인증 필터 종료");


### PR DESCRIPTION
## ✏️ 요약

JwtAccessToken 예외처리가 500 으로 잡히는 버그 수정
JwtProvider 클래스에서 예외처리를 CustomException 으로 처리하는데 JwtFilter 클래스에서는 try catch 문에 예외처리를 JwtException 으로 해서 발생한 버그




## 🏷️ 관련 이슈

24


