### PR TITLE
fix:JwtAccess예외처리 코드 버그 수정 

### DIFF
--- a/backend/src/main/java/io/linkloud/api/domain/member/api/MemberController.java
+++ b/backend/src/main/java/io/linkloud/api/domain/member/api/MemberController.java
@@ -27,6 +27,7 @@ public class MemberController {
 
     private final MemberService memberService;
 
+    // TODO : SecurityMember 가 null 일 경우 500 발생, (추후 현재 회원 요청을 따로 어노테이션으로 만들어서 처리해야 됨)
     @GetMapping("/me")
     public ResponseEntity<SingleDataResponse<MemberLoginResponse>> loginSuccess(
         @AuthenticationPrincipal SecurityMember securityMember) {

--- a/backend/src/main/java/io/linkloud/api/global/security/auth/jwt/filter/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/io/linkloud/api/global/security/auth/jwt/filter/JwtAuthenticationFilter.java
@@ -71,9 +71,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
                 log.info("Security Context 에 '{}' 인증 정보를 저장했습니다, uri: {}", authentication.getName(), requestURI);
             }
-        } catch (JwtException e) {
-            log.error("JWT parsing error: {}", e.getMessage());
-            response.setStatus(AuthExceptionCode.USER_UNAUTHORIZED.getStatus());
+        } catch (CustomException e) {
+            log.error("JWT error: {}", e.getMessage());
+            response.setStatus(e.getExceptionCode().getStatus());
             return;
         }
         log.info("JWT 인증 필터 종료");


### PR DESCRIPTION
## ✏️ 요약

JwtAccessToken 예외처리가 500 으로 잡히는 버그 수정

JwtProvider 클래스에서 예외처리를 CustomException 으로 처리하는데
JwtFilter 클래스에서는 try catch 문에 예외처리를 JwtException 으로 해서 발생한 버그




