### PR TITLE
fix:리프레시 토큰 요청 시 jwtFilter 작동 안하도록 변경 24

### DIFF
--- a/backend/src/main/java/io/linkloud/api/global/security/auth/jwt/filter/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/io/linkloud/api/global/security/auth/jwt/filter/JwtAuthenticationFilter.java
@@ -42,6 +42,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtProvider jwtProvider;
 
     private final MemberRepository memberRepository;
+    private static final String REFRESH_TOKEN_URI = "/api/v1/auth/refresh";
 
     @Override
     protected void doFilterInternal(
@@ -50,9 +51,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         @NonNull FilterChain filterChain) throws ServletException, IOException {
         String requestURI = request.getRequestURI();
 
+        if (requestURI.equals(REFRESH_TOKEN_URI)) {
+            log.info("리프레시토큰요청");
+            filterChain.doFilter(request, response);
+            return;
+        }
         // 1. Header 검증 후 Jwt Token 추출
         log.info("JWT 인증 필터 실행 = {}", HeaderUtil.getAccessToken(request));
         String accessToken = HeaderUtil.getAccessToken(request);
+
 
         try {
             // 2. 토큰이 유효한지 검증


### PR DESCRIPTION
## ✏️ 요약

refreshToken 요청 URI 일 경우, jwtFilter 가 작동하지 않도록 했습니다.

## ✨ 변경 사항

jwtFilter.class

## 🏷️ 관련 이슈

24

## 체크리스트

- [ ] 변경 사항이 테스트 되었는가?
- [ ] 코드 리뷰를 요청했는가?
