### PR TITLE
refactor:refresh토큰 요청시 응답 Dto 통일

### DIFF
--- a/backend/src/main/java/io/linkloud/api/domain/member/api/AuthController.java
+++ b/backend/src/main/java/io/linkloud/api/domain/member/api/AuthController.java
@@ -33,13 +33,13 @@ public class AuthController {
     }
 
     @PostMapping("/refresh")
-    public ResponseEntity<AuthResponseDto> refreshAccessToken(@RequestBody
+    public ResponseEntity<SingleDataResponse<AuthResponseDto>> refreshAccessToken(@RequestBody
     RefreshAccessTokenRequest dto) {
         AuthResponseDto responseDto = authService.refreshTokenAndAccessToken(dto.getRefreshToken(),
             dto.getTokenType());
         log.info("토큰 재생성");
         log.info("AccessToken={} ",responseDto.getAccessToken());
         log.info("RefreshToken={} ",responseDto.getRefreshToken());
-        return ResponseEntity.ok(responseDto);
+        return ResponseEntity.ok(new SingleDataResponse<>(responseDto));
     }
 }

--- a/backend/src/test/java/io/linkloud/api/domain/member/api/AuthControllerTest.java
+++ b/backend/src/test/java/io/linkloud/api/domain/member/api/AuthControllerTest.java
@@ -201,8 +201,8 @@ class AuthControllerTest {
                     fieldWithPath("tokenType").description("토큰 타입(Bearer )")
                     ),
                 responseFields(
-                    fieldWithPath("accessToken").description("새로 발급된 액세스 토큰"),
-                    fieldWithPath("refreshToken").description("새로 발급된 리프레시 토큰")
+                    fieldWithPath("data.accessToken").description("새로 발급된 액세스 토큰"),
+                    fieldWithPath("data.refreshToken").description("새로 발급된 리프레시 토큰")
                 )
             )
         );


### PR DESCRIPTION
## ✏️ 요약

refresh토큰 응답 시 SingleDataResponse 가 적용되지 않아 수정했습니다

## ✨ 변경 사항

/api/v1/auth/refresh 요청 시, 응답 dto 수정

## 🏷️ 관련 이슈



## 체크리스트

- [ ] 변경 사항이 테스트 되었는가?
- [ ] 코드 리뷰를 요청했는가?
