### PR TITLE
fix: 태그를 엔터키로 등록시 마지막 문자가 남던 현상

### DIFF
--- a/client/src/features/articles/hooks/useArticleReg.ts
+++ b/client/src/features/articles/hooks/useArticleReg.ts
@@ -103,11 +103,11 @@ export const useArticleReg = () => {
       return;
     }
 
+    setEnteredTagValue("");
     setForm((prev) => ({
       ...prev,
       tags: [...prev.tags, tag],
     }));
-    setEnteredTagValue("");
     setFormErrorMessage((prev) => ({
       ...prev,
       tags: "",

--- a/client/src/features/articles/pages/Reg.tsx
+++ b/client/src/features/articles/pages/Reg.tsx
@@ -22,8 +22,12 @@ const Reg = () => {
     handleSubmitArticle,
   } = useArticleReg();
 
-  const handleAddTags = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter" && e.currentTarget.id === "tag") {
+  const handleTagInputEnter = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (
+      e.key === "Enter" &&
+      e.currentTarget.id === "tag" &&
+      e.nativeEvent.isComposing === false
+    ) {
       e.preventDefault();
       handleAddTag();
     }
@@ -81,7 +85,7 @@ const Reg = () => {
                 errorMessage={formErrorMessage.tags}
                 className="mt-8 w-full"
                 onChange={handleChangeTags}
-                onKeyDown={handleAddTags}
+                onKeyDown={handleTagInputEnter}
               />
             </div>
             <div>


### PR DESCRIPTION
## ✏️ 요약

태그를 엔터키로 등록시 마지막 문자가 남던 현상 수정

## ✨ 변경 사항

(변경 사항 작성)

## 🏷️ 관련 이슈

#107 

