### PR TITLE
refactor: 게시글 tag 목록 dto 문자열 -> 객체 배열 수정

### DIFF
--- a/backend/src/main/java/io/linkloud/api/domain/article/dto/ArticleResponseDto.java
+++ b/backend/src/main/java/io/linkloud/api/domain/article/dto/ArticleResponseDto.java
@@ -1,6 +1,7 @@
 package io.linkloud.api.domain.article.dto;
 
 import io.linkloud.api.domain.article.model.Article;
+import io.linkloud.api.domain.tag.dto.TagDto;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -14,10 +15,6 @@ public class ArticleResponseDto {
 
     private Long id;
 
-    private Long memberId;
-
-    private String memberNickname;
-
     private String title;
 
     private String url;
@@ -28,13 +25,13 @@ public class ArticleResponseDto {
 
     private Integer hearts;
 
-    private List<String> tags;
+    private List<TagDto.ArticleTagsResponse> tags;
 
-    /** Entity -> Dto */
+    /**
+     * Entity -> Dto
+     */
     public ArticleResponseDto(Article article) {
         this.id = article.getId();
-        this.memberId = article.getMember().getId();    // article.getMember_id()에서 Member형의 member_id를 가져온 후, Member 아티클의 getter를 이용.
-        this.memberNickname = article.getMember().getNickname();
         this.title = article.getTitle();
         this.url = article.getUrl();
         this.description = article.getDescription();
@@ -42,7 +39,7 @@ public class ArticleResponseDto {
         this.hearts = article.getHearts();
         this.tags = new ArrayList<>();
         if (article.getArticleTags() != null && !article.getArticleTags().isEmpty()) {
-            article.getArticleTags().forEach(at -> this.tags.add(at.getTag().getName()));
+            article.getArticleTags().forEach(at -> this.tags.add(new TagDto.ArticleTagsResponse(at.getTag().getId(),at.getTag().getName())));
         }
     }
 

--- a/backend/src/main/java/io/linkloud/api/domain/tag/dto/TagDto.java
+++ b/backend/src/main/java/io/linkloud/api/domain/tag/dto/TagDto.java
@@ -18,4 +18,22 @@ public class TagDto {
         Long count;
     }
 
+    public static class ArticleTagsResponse {
+        private final Long id;
+        private final String name;
+
+        public ArticleTagsResponse(Long id, String name) {
+            this.id = id;
+            this.name = name;
+        }
+
+        public Long getId() {
+            return id;
+        }
+
+        public String getName() {
+            return name;
+        }
+    }
+
 }

--- a/backend/src/test/java/io/linkloud/api/domain/article/service/ArticleServiceTest.java
+++ b/backend/src/test/java/io/linkloud/api/domain/article/service/ArticleServiceTest.java
@@ -137,9 +137,6 @@ class ArticleServiceTest {
         assertThat(articleUpdateRequestDto.getUrl()).isEqualTo(articleResponseDto.getUrl());
         assertThat(articleUpdateRequestDto.getDescription()).isEqualTo(articleResponseDto.getDescription());
 
-        // 게시글 수정된 응답 dto 의 memberId 와 작성자의 memberId 같은지 테스트
-        assertThat(articleResponseDto.getMemberId()).isEqualTo(firstMockMember.getId());
-        assertThat(articleResponseDto.getMemberNickname()).isEqualTo(firstMockMember.getNickname());
     }
 
 


### PR DESCRIPTION
## ✏️ 요약

게시글 목록 조회 시, 해당 게시글의 태그응답을 문자열에서 객체 배열 응답으로 변경

## ✨ 변경 사항

- GetMapping("/api/v1/article")


변경 전
<img width="334" alt="image" src="https://github.com/linkloud/linkloud.io/assets/55350901/1b6cbba8-bb53-45b9-9466-c754e403fbad">

변경 후
<img width="444" alt="image" src="https://github.com/linkloud/linkloud.io/assets/55350901/d2426d71-c861-4495-bc41-34bf529f2d76">

변경
1. tags 응답 문자열 -> 객체 배열
2. memberId,memberNickname 삭제


## 🏷️ 관련 이슈

(관련 이슈 번호 작성)

## 체크리스트

- [ ] 변경 사항이 테스트 되었는가?
- [ ] 코드 리뷰를 요청했는가?
