### PR TITLE
Cleanup/single data response

### DIFF
--- a/backend/src/main/java/io/linkloud/api/domain/article/api/ArticleController.java
+++ b/backend/src/main/java/io/linkloud/api/domain/article/api/ArticleController.java
@@ -43,21 +43,21 @@ public class ArticleController {
 
     /** 아티클 한 개 조회 */
     @GetMapping("/{id}")
-    public ResponseEntity<SingleDataResponse<ArticleResponseDto>> getOneArticle(@PathVariable @Valid Long id) {
+    public ResponseEntity<ArticleResponseDto> getOneArticle(@PathVariable @Valid Long id) {
         ArticleResponseDto getOneArticleDto = articleService.fetchArticleById(id);
-
-        return ResponseEntity.ok(new SingleDataResponse<>(getOneArticleDto));
+        return ResponseEntity.ok((getOneArticleDto));
     }
+
 
     /** 아티클 작성 */
     @PostMapping
-    public ResponseEntity<SingleDataResponse<ArticleResponseDto>> createArticle(
+    public ResponseEntity<ArticleResponseDto> createArticle(
         @LoginMemberId Long memberId,
         @RequestBody @Valid ArticleRequestDto articleRequestDto) {
 
         ArticleResponseDto createdArticleDto = articleService.addArticle(memberId, articleRequestDto);
 
-        return ResponseEntity.ok(new SingleDataResponse<>(createdArticleDto));
+        return ResponseEntity.ok(createdArticleDto);
 
     }
 
@@ -65,13 +65,13 @@ public class ArticleController {
     // PutMapping   : 해당 리소스를 대체하는 메소드
     // PatchMapping : 리소스의 일부를 바꾸는 메소드
     @PutMapping("/{articleId}")
-    public ResponseEntity<SingleDataResponse<ArticleResponseDto>> putArticle(
+    public ResponseEntity<ArticleResponseDto> putArticle(
         @PathVariable Long articleId,
         @LoginMemberId Long memberId,
         @RequestBody @Valid ArticleUpdateDto articleUpdateDto) {
         ArticleResponseDto updatedArticleDto = articleService.updateArticle(articleId, memberId, articleUpdateDto);
 
-        return ResponseEntity.ok(new SingleDataResponse<>(updatedArticleDto));
+        return ResponseEntity.ok(updatedArticleDto);
 
     }
 
@@ -85,7 +85,7 @@ public class ArticleController {
 
     /** 검색 */
     @GetMapping("search")
-    public ResponseEntity<MultiDataResponse> getArticleBySearch(
+    public ResponseEntity<MultiDataResponse<ArticleResponseDto>> getArticleBySearch(
         @RequestParam String keyword,
         @RequestParam(required = false) List<String> tags,
         @Positive @RequestParam int page) {

--- a/backend/src/main/java/io/linkloud/api/domain/heart/api/HeartController.java
+++ b/backend/src/main/java/io/linkloud/api/domain/heart/api/HeartController.java
@@ -19,14 +19,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @Validated
-@RequestMapping("/api/v1/likes")
+@RequestMapping("a")
 public class HeartController {
 
     private final HeartService heartService;
 
     /** 좋아요 추가 */
     @PostMapping("/{articleId}")
-    public ResponseEntity<SingleDataResponse<HeartResponseDto>> createHeart(
+    public ResponseEntity<HeartResponseDto> createHeart(
         @LoginMemberId Long memberId,
         @PathVariable @Valid Long articleId,
         @RequestBody @Valid HeartRequestDto heartRequestDto) {
@@ -35,7 +35,7 @@ public class HeartController {
         // 좋아요 추가, 좋아요 삭제를 따로 나눠서 할 수 있음
         HeartResponseDto heartResponseDto = heartService.addHeart(memberId, articleId, heartRequestDto);
 
-        return ResponseEntity.ok(new SingleDataResponse<>(heartResponseDto));
+        return ResponseEntity.ok(heartResponseDto);
     }
 
     /** 좋아요 취소 */

--- a/backend/src/main/java/io/linkloud/api/domain/member/api/AuthController.java
+++ b/backend/src/main/java/io/linkloud/api/domain/member/api/AuthController.java
@@ -25,21 +25,21 @@ public class AuthController {
 
 
     @PostMapping("/{socialType}")
-    public ResponseEntity<SingleDataResponse<AuthResponseDto>> authenticate(
+    public ResponseEntity<AuthResponseDto> authenticate(
         @RequestBody AuthRequestDto dto, HttpServletResponse response) {
         AuthResponseDto responseDto = authService.authenticate(dto,response);
         log.info("첫 토큰 생성");
         log.info("AccessToken={}",responseDto.getAccessToken());
-        return ResponseEntity.ok(new SingleDataResponse<>(responseDto));
+        return ResponseEntity.ok(responseDto);
     }
 
     @GetMapping("/refresh")
-    public ResponseEntity<SingleDataResponse<AuthResponseDto>> refreshAccessToken(
+    public ResponseEntity<AuthResponseDto> refreshAccessToken(
         @CookieValue("refreshToken") String refreshToken,
         HttpServletResponse response) {
         AuthResponseDto responseDto = authService.refreshTokenAndAccessToken(refreshToken,response);
         log.info("토큰 재생성");
         log.info("AccessToken={} ", responseDto.getAccessToken());
-        return ResponseEntity.ok(new SingleDataResponse<>(responseDto));
+        return ResponseEntity.ok(responseDto);
     }
 }

--- a/backend/src/main/java/io/linkloud/api/domain/member/api/MemberController.java
+++ b/backend/src/main/java/io/linkloud/api/domain/member/api/MemberController.java
@@ -35,10 +35,10 @@ public class MemberController {
     private final MemberService memberService;
 
     @GetMapping("/me")
-    public ResponseEntity<SingleDataResponse<MemberLoginResponse>> findMe(
+    public ResponseEntity<MemberLoginResponse> findMe(
             @NonNull @LoginMemberId Long loginMemberId) {
         MemberLoginResponse memberLoginResponse = memberService.fetchPrincipal(loginMemberId);
-        return ResponseEntity.ok(new SingleDataResponse<>(memberLoginResponse));
+        return ResponseEntity.ok(memberLoginResponse);
     }
 
     @PatchMapping("/nickname")
@@ -64,13 +64,13 @@ public class MemberController {
     }
 
     @PatchMapping("{memberId}/article-status/{articleId}")
-    public ResponseEntity<SingleDataResponse<ArticleStatusResponse>> updateMyArticlesStatus(
+    public ResponseEntity<ArticleStatusResponse> updateMyArticlesStatus(
             @PathVariable Long memberId,
             @PathVariable Long articleId,
             @LoginMemberId Long extractedMemberId,
             @RequestBody ArticleStatusRequest articleStatusRequest) {
         ArticleStatusResponse article = memberService.updateMyArticleStatus(memberId, extractedMemberId, articleId, articleStatusRequest);
-        return ResponseEntity.ok(new SingleDataResponse<>(article));
+        return ResponseEntity.ok(article);
     }
 
     @GetMapping("/{memberId}/tags")

--- a/backend/src/main/java/io/linkloud/api/domain/tag/api/TagController.java
+++ b/backend/src/main/java/io/linkloud/api/domain/tag/api/TagController.java
@@ -41,6 +41,6 @@ public class TagController {
     @GetMapping("/search")
     public ResponseEntity<?> getTagListBySearch(@RequestParam String keyword) {
         List<Response> tags = tagService.fetchTagListBySearch(keyword);
-        return ResponseEntity.ok().body(new SingleDataResponse<>(tags));
+        return ResponseEntity.ok().body(tags);
     }
 }

--- a/backend/src/test/java/io/linkloud/api/domain/member/api/AuthControllerTest.java
+++ b/backend/src/test/java/io/linkloud/api/domain/member/api/AuthControllerTest.java
@@ -85,7 +85,7 @@ class AuthControllerTest {
                     fieldWithPath("code").description("일회용 oauth 액세스 토큰 요청 인가 코드")
                 ),
                     responseFields(
-                            fieldWithPath("data.accessToken").description("Access Token")
+                            fieldWithPath("accessToken").description("Access Token")
                     )
             ));
         verify(authService).authenticate(any(),any());
@@ -201,7 +201,7 @@ class AuthControllerTest {
                                         fieldWithPath("refreshToken").description("리프레시 토큰")
                                 ),
                                 responseFields(
-                                        fieldWithPath("data.accessToken").description("새로 발급된 액세스 토큰")
+                                        fieldWithPath("accessToken").description("새로 발급된 액세스 토큰")
                                 )
                         )
                 );

--- a/backend/src/test/java/io/linkloud/api/domain/member/api/MemberControllerTest.java
+++ b/backend/src/test/java/io/linkloud/api/domain/member/api/MemberControllerTest.java
@@ -208,17 +208,17 @@ class MemberControllerTest {
         actions
             .andDo(print())
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.data.nickname").value(member.getNickname()))
-            .andExpect(jsonPath("$.data.picture").value(member.getPicture()))
-            .andExpect(jsonPath("$.data.role").value(member.getRole().name()))
+            .andExpect(jsonPath("$.nickname").value(member.getNickname()))
+            .andExpect(jsonPath("$.picture").value(member.getPicture()))
+            .andExpect(jsonPath("$.role").value(member.getRole().name()))
             .andDo(document("member/me/success/newMember",
                 preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint()),
                 responseFields(
-                    fieldWithPath("data.id").description("회원의 PK ID"),
-                    fieldWithPath("data.nickname").description("회원의 닉네임."),
-                    fieldWithPath("data.picture").description("회원의 프로필 사진 URI."),
-                    fieldWithPath("data.role").description("가입한지 3일 이내 회원의 권한")
+                    fieldWithPath("id").description("회원의 PK ID"),
+                    fieldWithPath("nickname").description("회원의 닉네임."),
+                    fieldWithPath("picture").description("회원의 프로필 사진 URI."),
+                    fieldWithPath("role").description("가입한지 3일 이내 회원의 권한")
                 )));
     }
 
@@ -239,10 +239,10 @@ class MemberControllerTest {
                 preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint()),
                 responseFields(
-                    fieldWithPath("data.id").description("회원의 PK ID"),
-                    fieldWithPath("data.nickname").description("회원의 닉네임."),
-                    fieldWithPath("data.picture").description("회원의 프로필 사진 URI."),
-                    fieldWithPath("data.role").description("가입한지 3일 지난 회원의 권한")
+                    fieldWithPath("id").description("회원의 PK ID"),
+                    fieldWithPath("nickname").description("회원의 닉네임."),
+                    fieldWithPath("picture").description("회원의 프로필 사진 URI."),
+                    fieldWithPath("role").description("가입한지 3일 지난 회원의 권한")
                 )));
     }
 
@@ -498,8 +498,8 @@ class MemberControllerTest {
                                 fieldWithPath("readStatus").description("변경할 게시글의 상태")
                         ),
                         responseFields(
-                                fieldWithPath("data.articleId").description("변경된 게시글PK ID"),
-                                fieldWithPath("data.readStatus").description("변경된 게시글 상태")
+                                fieldWithPath("articleId").description("변경된 게시글PK ID"),
+                                fieldWithPath("readStatus").description("변경된 게시글 상태")
                         )));
 
         // READING
@@ -527,8 +527,8 @@ class MemberControllerTest {
                                 fieldWithPath("readStatus").description("변경할 게시글의 상태")
                         ),
                         responseFields(
-                                fieldWithPath("data.articleId").description("변경된 게시글PK ID"),
-                                fieldWithPath("data.readStatus").description("변경된 게시글 상태")
+                                fieldWithPath("articleId").description("변경된 게시글PK ID"),
+                                fieldWithPath("readStatus").description("변경된 게시글 상태")
                         )));
 
         // READ
@@ -556,8 +556,8 @@ class MemberControllerTest {
                                 fieldWithPath("readStatus").description("변경할 게시글의 상태")
                         ),
                         responseFields(
-                                fieldWithPath("data.articleId").description("변경된 게시글PK ID"),
-                                fieldWithPath("data.readStatus").description("변경된 게시글 상태")
+                                fieldWithPath("articleId").description("변경된 게시글PK ID"),
+                                fieldWithPath("readStatus").description("변경된 게시글 상태")
                         )));
 
     }


### PR DESCRIPTION
## ✏️ 요약

SingleDataResponse 제거

## ✨ 변경 사항

게시글
- /api/v1/article
Get("/api/v1/article/{id}") : 게시글 한개 조회
Post("/api/v1/article/{id}") : 게시글 생성
Put("/api/v1/article/{articledId}") : 게시글 수정

---

좋아요
- /api/v1/likes
  Post("/api/v1/likes/{articleId}") : 게시글에 좋아요 추가

---

회원 인증/인가
- /api/v1/auth
Post("/api/v1/auth/{socialType}") : 소셜 미디어 타입으로 인증 및 인가 요청
Get("/api/v1/auth/refresh") : 리프레시 토큰 갱신을 위한 요청

---

회원 프로필
- /api/v1/member
Get("/api/v1/member/me") : 현재 로그인한 회원의 프로필 정보 조회
Patch("/api/v1/member/{memberId}/article-status/{articleId}") : 회원의 특정 게시글 상태 업데이트

---

태그
- /api/v1/tags
Get("/api/v1/tags/search") : 태그 검색

---
### 해당 엔드포인트들의 응답이 변경되었습니다
---
# 변경 전

<img width="513" alt="image" src="https://github.com/linkloud/linkloud.io/assets/55350901/581c4107-e349-477a-917e-dee1d680b2ed">

# 변경 후

<img width="548" alt="image" src="https://github.com/linkloud/linkloud.io/assets/55350901/791968b7-f046-4b09-9f6f-8a472be53745">




## 체크리스트

- [ ] 변경 사항이 테스트 되었는가?
- [ ] 코드 리뷰를 요청했는가?
