### PR TITLE
Feat/open graph

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -71,6 +71,10 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'com.h2database:h2' // 테스트용 인 메모리 DB
     implementation 'com.google.code.gson:gson'
+
+    // jsoup
+    implementation 'org.jsoup:jsoup:1.16.1'
+
 }
 
 // querydsl 시작

--- a/backend/src/main/java/io/linkloud/api/domain/article/api/ArticleControllerV2.java
+++ b/backend/src/main/java/io/linkloud/api/domain/article/api/ArticleControllerV2.java
@@ -20,7 +20,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -69,8 +68,8 @@ public class ArticleControllerV2 {
     @PutMapping("/{id}")
     public ResponseEntity<ArticleUpdate> updateArticle(
         @PathVariable("id") Long articleId,
+        @LoginMemberId Long loginMemberId,
         @RequestBody @Valid ArticleUpdateRequestDto updateRequestDto) {
-        Long loginMemberId = 1L;
         ArticleUpdate articleUpdate = articleServiceV2.updateArticle(updateRequestDto, articleId,
             loginMemberId);
 

--- a/backend/src/main/java/io/linkloud/api/domain/article/dto/ArticleRequestDtoV2.java
+++ b/backend/src/main/java/io/linkloud/api/domain/article/dto/ArticleRequestDtoV2.java
@@ -24,6 +24,8 @@ public class ArticleRequestDtoV2 {
         @Size(max = 255, message = "본문은 255자 이하로 작성해야 합니다.")
         String description,
 
+        String ogImage,
+
         @Size(max = 5)
         List<@Pattern(regexp = "^[0-9A-Za-z가-힣-]*$")
         @NotBlank
@@ -36,6 +38,7 @@ public class ArticleRequestDtoV2 {
                 .title(title)
                 .url(url)
                 .description(description)
+                .ogImage(ogImage)
                 .build();
         }
     }

--- a/backend/src/main/java/io/linkloud/api/domain/article/dto/ArticleRequestDtoV2.java
+++ b/backend/src/main/java/io/linkloud/api/domain/article/dto/ArticleRequestDtoV2.java
@@ -59,6 +59,8 @@ public class ArticleRequestDtoV2 {
         @Size(max = 255, message = "본문은 255자 이하로 작성해야 합니다.")
         private String description;
 
+        private String ogImage;
+
         @Size(max = 5)
         private List<
             @Pattern(regexp = "^[0-9A-Za-z가-힣-]*$")

--- a/backend/src/main/java/io/linkloud/api/domain/article/dto/ArticleResponseDto.java
+++ b/backend/src/main/java/io/linkloud/api/domain/article/dto/ArticleResponseDto.java
@@ -28,6 +28,8 @@ public class ArticleResponseDto implements HasId {
 
     private List<TagDto.ArticleTagsResponse> tags;
 
+    private String ogImage;
+
     @Override
     public Long getId() {
         return this.id;
@@ -47,5 +49,6 @@ public class ArticleResponseDto implements HasId {
             article.getArticleTags().forEach(at -> this.tags.add(
                 new TagDto.ArticleTagsResponse(at.getTag().getId(), at.getTag().getName())));
         }
+        this.ogImage = article.getOgImage();
     }
  }

--- a/backend/src/main/java/io/linkloud/api/domain/article/dto/ArticleResponseDtoV2.java
+++ b/backend/src/main/java/io/linkloud/api/domain/article/dto/ArticleResponseDtoV2.java
@@ -33,6 +33,8 @@ public class ArticleResponseDtoV2 {
 
         private List<TagDto.ArticleTagsResponse> tags;
 
+        private String ogImage;
+
         /**
          * Entity -> Dto
          */
@@ -48,6 +50,7 @@ public class ArticleResponseDtoV2 {
                 article.getArticleTags().forEach(at -> this.tags.add(
                     new TagDto.ArticleTagsResponse(at.getTag().getId(), at.getTag().getName())));
             }
+            this.ogImage = article.getOgImage();
         }
     }
 

--- a/backend/src/main/java/io/linkloud/api/domain/article/model/Article.java
+++ b/backend/src/main/java/io/linkloud/api/domain/article/model/Article.java
@@ -94,6 +94,7 @@ public class Article extends Auditable {
         this.title = updateDto.getTitle();
         this.url = updateDto.getUrl();
         this.description = updateDto.getDescription();
+        this.ogImage = updateDto.getOgImage();
     }
 
     /** 조회수 변동 */

--- a/backend/src/main/java/io/linkloud/api/domain/article/model/Article.java
+++ b/backend/src/main/java/io/linkloud/api/domain/article/model/Article.java
@@ -55,6 +55,8 @@ public class Article extends Auditable {
     @Enumerated(EnumType.STRING)
     private ReadStatus readStatus = ReadStatus.UNREAD;
 
+    @Column(nullable = true)
+    private String ogImage;
     @AllArgsConstructor
     public enum SortBy {
         LATEST("createdAt"),
@@ -69,12 +71,13 @@ public class Article extends Auditable {
 
     /** 생성자 */
     @Builder
-    public Article(Long id, Member member, String title, String url, String description, Integer views, Integer hearts) {
+    public Article(Long id, Member member, String title, String url, String description, Integer views, Integer hearts,String ogImage) {
         this.id = id;
         this.member = member;
         this.title = title;
         this.url = url;
         this.description = description;
+        this.ogImage = ogImage;
         this.views = views == null ? 0 : views; // 기본값 0으로 설정
         this.hearts = hearts == null ? 0 : hearts;
     }

--- a/backend/src/main/java/io/linkloud/api/domain/openGraph/api/OpenGraphController.java
+++ b/backend/src/main/java/io/linkloud/api/domain/openGraph/api/OpenGraphController.java
@@ -1,0 +1,28 @@
+package io.linkloud.api.domain.openGraph.api;
+
+import io.linkloud.api.domain.openGraph.dto.OpenGraphDto;
+import io.linkloud.api.domain.openGraph.service.OpenGraphService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/api/v2/opengraph")
+@RestController
+public class OpenGraphController {
+
+    private final OpenGraphService openGraphService;
+
+    @GetMapping
+    public ResponseEntity<OpenGraphDto> getOpenGraph(@RequestParam String targetUrl) {
+        log.info("OpenGraph URL Request : {}",targetUrl);
+        OpenGraphDto responseDto = openGraphService.getOpenGraphData(targetUrl);
+        return ResponseEntity.ok(responseDto);
+    }
+
+}

--- a/backend/src/main/java/io/linkloud/api/domain/openGraph/dto/OpenGraphDto.java
+++ b/backend/src/main/java/io/linkloud/api/domain/openGraph/dto/OpenGraphDto.java
@@ -1,0 +1,23 @@
+package io.linkloud.api.domain.openGraph.dto;
+
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class OpenGraphDto {
+
+    private final String title;
+    private final String image;
+    private final String url;
+    private final String description;
+
+
+    @Builder
+    public OpenGraphDto(String title, String image, String url, String description) {
+        this.title = title;
+        this.image = image;
+        this.url = url;
+        this.description = description;
+    }
+}

--- a/backend/src/main/java/io/linkloud/api/domain/openGraph/dto/OpenGraphDto.java
+++ b/backend/src/main/java/io/linkloud/api/domain/openGraph/dto/OpenGraphDto.java
@@ -8,15 +8,15 @@ import lombok.Getter;
 public class OpenGraphDto {
 
     private final String title;
-    private final String image;
+    private final String ogImage;
     private final String url;
     private final String description;
 
 
     @Builder
-    public OpenGraphDto(String title, String image, String url, String description) {
+    public OpenGraphDto(String title, String ogImage, String url, String description) {
         this.title = title;
-        this.image = image;
+        this.ogImage = ogImage;
         this.url = url;
         this.description = description;
     }

--- a/backend/src/main/java/io/linkloud/api/domain/openGraph/service/OpenGraphService.java
+++ b/backend/src/main/java/io/linkloud/api/domain/openGraph/service/OpenGraphService.java
@@ -36,7 +36,7 @@ public class OpenGraphService {
             return OpenGraphDto.builder()
                 .title(title)
                 .description(description)
-                .image(image)
+                .ogImage(image)
                 .url(url)
                 .build();
 

--- a/backend/src/main/java/io/linkloud/api/domain/openGraph/service/OpenGraphService.java
+++ b/backend/src/main/java/io/linkloud/api/domain/openGraph/service/OpenGraphService.java
@@ -1,0 +1,49 @@
+package io.linkloud.api.domain.openGraph.service;
+
+import io.linkloud.api.domain.openGraph.dto.OpenGraphDto;
+import io.linkloud.api.global.exception.CustomException;
+import io.linkloud.api.global.exception.ExceptionCode.LogicExceptionCode;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class OpenGraphService {
+
+    private static final String OG_TITLE = "meta[property=og:title]";
+    private static final String OG_IMAGE = "meta[property=og:image]";
+    private static final String OG_URL = "meta[property=og:url]";
+    private static final String OG_DESCRIPTION = "meta[property=og:description]";
+    private static final String CONTENT = "content";
+
+    // TODO : 외부 라이브러리 사용해서 느림 캐시 적용해야 됨
+    public OpenGraphDto getOpenGraphData(String targetUrl) {
+        try {
+            Document doc = Jsoup.connect(targetUrl).get();
+            String title = doc.select(OG_TITLE).attr(CONTENT);
+            String image = doc.select(OG_IMAGE).attr(CONTENT);
+            String url = doc.select(OG_URL).attr(CONTENT);
+            String description = doc.select(OG_DESCRIPTION).attr(CONTENT);
+            log.info("OpenGraph Request Success");
+            log.info("OpenGraph title = {}",title);
+            log.info("OpenGraph image = {}",image);
+            log.info("OpenGraph url = {}",url);
+            log.info("OpenGraph description = {}",description);
+
+            return OpenGraphDto.builder()
+                .title(title)
+                .description(description)
+                .image(image)
+                .url(url)
+                .build();
+
+        } catch (IOException e) {
+            log.error("잘못된 openGraph URL: {}",targetUrl);
+            throw new CustomException(LogicExceptionCode.BAD_REQUEST);
+        }
+    }
+
+}

--- a/backend/src/main/java/io/linkloud/api/domain/openGraph/service/OpenGraphService.java
+++ b/backend/src/main/java/io/linkloud/api/domain/openGraph/service/OpenGraphService.java
@@ -40,7 +40,7 @@ public class OpenGraphService {
                 .url(url)
                 .build();
 
-        } catch (IOException e) {
+        } catch (Exception e) {
             log.error("잘못된 openGraph URL: {}",targetUrl);
             throw new CustomException(LogicExceptionCode.BAD_REQUEST);
         }


### PR DESCRIPTION
## ✏️ 요약

# OpenGraph API
- **설명: targetUrl 에 따른 해당 사이트 og 정보 가져옴**
- **Method: GET**
- **URL: /api/v2/opengraph**
- **Parameters:**
        **- targetUrl: og 태그 정보 요청할 url 주소**

## 요청 예
**GET** api/v2/opengraph?targetUrl=https://www.naver.com

<img width="718" alt="image" src="https://github.com/linkloud/linkloud.io/assets/55350901/b95b3d7a-4016-41a0-9dbc-f880d561e513">

## 잘못된 URL
**GET**  api/v2/opengraph?targetUrl=httpㅇㄹs://ㅁㅇㅇㄹㅁㄴㄹㅇㄴㄹㅇㄴdffd

<img width="254" alt="image" src="https://github.com/linkloud/linkloud.io/assets/55350901/6c1042e2-0684-4157-95b6-80a734cc6c25">



## ✨ 변경 사항

# Article API
## 1. 게시글 저장 
- **openGraph 추가됨에 따라 게시글을 저장할 때 ogImage 를 추가로 받음**

### 변경 전 요청

- **Method: POST**
- **URL: /api/v2/articles**
<img width="333" alt="image" src="https://github.com/linkloud/linkloud.io/assets/55350901/3d326603-77eb-485d-8f90-2a15d6e3a3ad">


### 변경 후 요청
  
<img width="739" alt="image" src="https://github.com/linkloud/linkloud.io/assets/55350901/8f192814-c5a9-4fb3-9766-32ec2ec25ae4">

---
## 2. 게시글 응답
- **openGraph 추가됨에 따라 게시글 목록 조회 할 때 ogImage 가 추가 됨**
- **Method: GET**
- **URL**
   - /api/v2/articles
   - /api/v2/articles/{id}
   - /api/v2/articles/search
### 변경 전 응답


<img width="383" alt="image" src="https://github.com/linkloud/linkloud.io/assets/55350901/2925d37c-d167-4c4a-873d-50664b2c5615">

### 변경 후 응답

<img width="733" alt="image" src="https://github.com/linkloud/linkloud.io/assets/55350901/5e700ae7-8e21-46b7-b3b8-1b1fb74ac7b4">


## 🏷️ 관련 이슈

(관련 이슈 번호 작성)

## 체크리스트

- [ ] 변경 사항이 테스트 되었는가?
- [ ] 코드 리뷰를 요청했는가?
