### PR TITLE
refactor:lastArtileId -> nextId

### DIFF
--- a/backend/src/main/java/io/linkloud/api/domain/article/api/ArticleControllerV2.java
+++ b/backend/src/main/java/io/linkloud/api/domain/article/api/ArticleControllerV2.java
@@ -37,14 +37,17 @@ public class ArticleControllerV2 {
 
     private final ArticleServiceV2 articleServiceV2;
 
+    //lastArticleId -> nextId
+    //lastId 없으면 1페이지 조회, 즉최신순부터 요청 개수만큼 조회
+
     // 게시글 목록 조회
     @GetMapping
     public ResponseEntity<SliceResponse<ArticleResponseDto>> getArticles(
-        @RequestParam Long lastArticleId,
+        @RequestParam(required = false) Long nextId,
         Pageable pageable,
         @RequestParam(required = false,defaultValue = "latest") SortBy sortBy) {
         Slice<ArticleResponseDto> articlesSlice = articleServiceV2.findArticlesWithNoOffset(
-            lastArticleId, pageable,sortBy);
+            nextId, pageable,sortBy);
         return ResponseEntity.ok(new SliceResponse<>(articlesSlice));
     }
 

--- a/backend/src/main/java/io/linkloud/api/domain/member/api/MemberControllerV2.java
+++ b/backend/src/main/java/io/linkloud/api/domain/member/api/MemberControllerV2.java
@@ -35,26 +35,26 @@ public class MemberControllerV2 {
     // 내가 작성한 게시글 목록 인기순,최신순 조회
     @GetMapping("/{memberId}/articles")
     public ResponseEntity<SliceResponse<MemberArticlesSortedResponse>> getArticles(
-        @RequestParam Long lastArticleId,
+        @RequestParam(required = false) Long nextId,
         Pageable pageable,
         @RequestParam SortBy sortBy,
         @LoginMemberId Long loginMemberId,
         @PathVariable Long memberId) {
         Slice<MemberArticlesSortedResponse> myArticles = articleServiceV2.findArticlesByMemberSorted(
-            loginMemberId, memberId, lastArticleId, pageable, sortBy);
+            loginMemberId, memberId, nextId, pageable, sortBy);
         return ResponseEntity.ok(new SliceResponse<>(myArticles));
     }
 
     // 내가 변경한 다른 사람의 게시글 상태로 조회
     @GetMapping("/{memberId}/read-status")
     public ResponseEntity<SliceResponse<MemberArticlesByReadStatus>> getMemberArticlesByStatus(
-        @RequestParam Long lastArticleId,
+        @RequestParam(required = false) Long nextId,
         Pageable pageable,
         @LoginMemberId Long loginMemberId,
         @PathVariable Long memberId,
         @RequestParam ReadStatus readStatus) {
         Slice<MemberArticlesByReadStatus> myArticles = articleServiceV2.findArticlesByReadStatus(loginMemberId,
-            memberId, lastArticleId, pageable, readStatus);
+            memberId, nextId, pageable, readStatus);
         return ResponseEntity.ok(new SliceResponse<>(myArticles));
     }
 


### PR DESCRIPTION
## ✏️ 요약

lastArticleId -> nextId 로 변경 됨
nextId 요청하지 않을 시 최신순부터 요청 개수(size=50) 개 만큼 조회

## ✨ 변경 사항

### GET /api/v2/articles ( 게시글 목록 조회 )
- 변경 전
  - api/v2/member/1/articles?**lastArticleId**=123&size=5&sortBy=latest
- 변경 후 
  - api/v2/member/1/articles?**nextId**=123&size=5&sortBy=latest

### GET /api/v2/member/{memberId}/articles ( 내가 작성한 게시글 인기순,최신순 조회)
- 변경 전 
    - api/v2/member/1/articles?**lastArticleId**=123&size=5&sortBy=latest
- 변경 후
    - api/v2/member/1/articles?**nextId**=123&size=5&sortBy=latest



### GET /api/v2/member/{memberId}/read-status ( 게시글 상태별로 목록 조회 )
- 변경 전 
    - /api/v2/member/1/read-status?**lastArticleId**=20&size=100&readStatus=read
- 변경 후
    - /api/v2/member/1/read-status?**nextId**=20&size=100&readStatus=read

## 🏷️ 관련 이슈

(관련 이슈 번호 작성)

## 체크리스트

- [ ] 변경 사항이 테스트 되었는가?
- [ ] 코드 리뷰를 요청했는가?
