### PR TITLE
fix:게시글 목록 조회 nextId 초기 값 버그 수정

### DIFF
--- a/backend/src/main/java/io/linkloud/api/domain/article/service/ArticleServiceV2Impl.java
+++ b/backend/src/main/java/io/linkloud/api/domain/article/service/ArticleServiceV2Impl.java
@@ -115,11 +115,20 @@ public class ArticleServiceV2Impl implements ArticleServiceV2{
     @Override
     public Slice<ArticleListResponse> findArticlesWithNoOffset(Long nextId,Long loginMemberId, Pageable pageable,
         SortBy sortBy) {
+
+
         Slice<ArticleListResponse> articlesWithNoOffset = articleRepository.findArticlesWithNoOffset(
             nextId, pageable, sortBy);
 
+
         if (loginMemberId != null) {
-            long endArticleId = nextId - 1;
+            long endArticleId;
+            if (nextId == null) {
+                endArticleId = articlesWithNoOffset.getContent()
+                    .get(articlesWithNoOffset.getSize() - 1).getId();
+            }else {
+             endArticleId = nextId - 1;
+            }
             long startArticleId = endArticleId - pageable.getPageSize() + 1;
 
             flagArticlesForLoggedInMember(loginMemberId, startArticleId, endArticleId,


### PR DESCRIPTION
## ✏️ 요약

게시글 목록 조회 시 로그인 한 유저일 경우 게시글 목록중에 해당 회원이 작성한 글,설정한 게시글 상태,좋아요 여부 반환

## ✨ 변경 사항




## 🏷️ 관련 이슈

(관련 이슈 번호 작성)

## 체크리스트

- [ ] 변경 사항이 테스트 되었는가?
- [ ] 코드 리뷰를 요청했는가?
