### PR TITLE
Fix/my articles and tag valid

### DIFF
--- a/backend/src/main/java/io/linkloud/api/domain/article/dto/ArticleRequestDtoV2.java
+++ b/backend/src/main/java/io/linkloud/api/domain/article/dto/ArticleRequestDtoV2.java
@@ -21,6 +21,7 @@ public class ArticleRequestDtoV2 {
         @Size(max = 255, message = "링크의 길이가 너무 깁니다.")
         String url,
 
+        @NotBlank(message = "본문은 빈칸으로 둘 수 없습니다.")
         @Size(max = 255, message = "본문은 255자 이하로 작성해야 합니다.")
         String description,
 

--- a/backend/src/main/java/io/linkloud/api/domain/article/model/Article.java
+++ b/backend/src/main/java/io/linkloud/api/domain/article/model/Article.java
@@ -65,6 +65,15 @@ public class Article extends Auditable {
 
         @Getter
         private final String sortBy;
+
+        public static SortBy fromString(String value) {
+            for (SortBy sortBy : SortBy.values()) {
+                if (sortBy.sortBy.equalsIgnoreCase(value)) {
+                    return sortBy;
+                }
+            }
+            return null;
+        }
     }
 
     /** 생성자 */

--- a/backend/src/main/java/io/linkloud/api/domain/article/model/ReadStatus.java
+++ b/backend/src/main/java/io/linkloud/api/domain/article/model/ReadStatus.java
@@ -1,10 +1,10 @@
 package io.linkloud.api.domain.article.model;
 
-import lombok.AllArgsConstructor;
+import io.linkloud.api.global.exception.CustomException;
+import io.linkloud.api.global.exception.ExceptionCode.LogicExceptionCode;
 import lombok.Getter;
 
 
-@AllArgsConstructor
 @Getter
 public enum ReadStatus {
     UNREAD("unread"),
@@ -12,6 +12,15 @@ public enum ReadStatus {
     READ("read");
 
     private String status;
-
-
+    ReadStatus(String status) {
+        this.status = status;
+    }
+    public static ReadStatus fromString(String value) {
+        for (ReadStatus status : ReadStatus.values()) {
+            if (status.status.equalsIgnoreCase(value)) {
+                return status;
+            }
+        }
+        return null;
+    }
 }

--- a/backend/src/main/java/io/linkloud/api/domain/article/model/ReadStatus.java
+++ b/backend/src/main/java/io/linkloud/api/domain/article/model/ReadStatus.java
@@ -1,7 +1,6 @@
 package io.linkloud.api.domain.article.model;
 
-import io.linkloud.api.global.exception.CustomException;
-import io.linkloud.api.global.exception.ExceptionCode.LogicExceptionCode;
+
 import lombok.Getter;
 
 

--- a/backend/src/main/java/io/linkloud/api/domain/article/service/ArticleServiceV2.java
+++ b/backend/src/main/java/io/linkloud/api/domain/article/service/ArticleServiceV2.java
@@ -29,7 +29,7 @@ public interface ArticleServiceV2 {
 
 
     Slice<MemberArticlesByCondition> MemberArticlesByCondition(Long loginMemberId, Long memberId,
-        Long lastArticleId, Pageable pageable, ReadStatus readStatus,SortBy sortBy);
+        Long lastArticleId, Pageable pageable, String sortBy);
 
 
     Slice<ArticleListResponse> searchArticleByKeywordOrTags(Long loginMemberId,String keyword, List<String> tags,Pageable pageable);

--- a/backend/src/main/java/io/linkloud/api/domain/article/service/ArticleServiceV2Impl.java
+++ b/backend/src/main/java/io/linkloud/api/domain/article/service/ArticleServiceV2Impl.java
@@ -133,10 +133,12 @@ public class ArticleServiceV2Impl implements ArticleServiceV2{
     @Transactional(readOnly = true)
     @Override
     public Slice<MemberArticlesByCondition> MemberArticlesByCondition(Long loginMemberId, Long memberId,
-        Long lastArticleId, Pageable pageable,ReadStatus readStatus ,SortBy sortBy) {
+        Long lastArticleId, Pageable pageable,String sortBy) {
+
         memberService.validateMember(memberId, loginMemberId);
-        return articleRepository.MemberArticlesByCondition(memberId, sortBy, readStatus,
-            lastArticleId, pageable);
+        ReadStatus readStatus = ReadStatus.fromString(sortBy);
+        SortBy titleOrLatest = SortBy.fromString(sortBy);
+        return articleRepository.MemberArticlesByCondition(memberId, titleOrLatest,readStatus, lastArticleId, pageable);
     }
 
 

--- a/backend/src/main/java/io/linkloud/api/domain/member/api/MemberControllerV2.java
+++ b/backend/src/main/java/io/linkloud/api/domain/member/api/MemberControllerV2.java
@@ -40,12 +40,11 @@ public class MemberControllerV2 {
     public ResponseEntity<SliceResponse<MemberArticlesByCondition>> getArticlesByCondition(
         @RequestParam(required = false) Long nextId,
         Pageable pageable,
-        @RequestParam(required = false) SortBy sortBy,
-        @RequestParam(required = false) ReadStatus readStatus,
         @LoginMemberId(required = false) Long loginMemberId,
+        @RequestParam String sortBy,
         @PathVariable Long memberId) {
         Slice<MemberArticlesByCondition> memberArticlesByCondition = articleServiceV2.MemberArticlesByCondition(loginMemberId, memberId,
-            nextId, pageable, readStatus, sortBy);
+            nextId, pageable, sortBy);
         return ResponseEntity.ok(new SliceResponse<>(memberArticlesByCondition));
     }
 


### PR DESCRIPTION
## ✏️ 요약

1. 회원 게시글 조회 요청 파라매터 통일 
    - GET | /api/v2/member/{memberId}/articles

2. 게시글 저장 시 게시글 설명없으면 
    - "본문은 빈칸으로 둘 수 없습니다" 유효성 추가



## ✨ 변경 사항

- 변경 전 
   - 회원 게시글 정렬 조회 (sortBy=title,latest) optional
   - 회원 게시글 상태 조회 (readStatus=unread,read,reading) optional
   - GET | /api/v2/member/{memberId}/articles?sortBy=title
   - GET | /api/v2/member/{memberId}/articles?readStatus=reading
  
- 변경 후
   - 회원 게시글 정렬 또는 상태로 조회 (sortBy=title,latest,unread,read,reading) required 
   - GET | /api/v2/member/{memberId}/articles?sortBy=title
   - GET | /api/v2/member/{memberId}/articles?sortBy=latest
   - GET | /api/v2/member/{memberId}/articles?sortBy=unread
   - GET | /api/v2/member/{memberId}/articles?sortBy=read
   - GET | /api/v2/member/{memberId}/articles?sortBy=reading


## 🏷️ 관련 이슈

(관련 이슈 번호 작성)

## 체크리스트

- [ ] 변경 사항이 테스트 되었는가?
- [ ] 코드 리뷰를 요청했는가?
