### PR TITLE
feat:내 게시글 조회 시, 게시글 목록중 작성자 여부

### DIFF
--- a/backend/src/main/java/io/linkloud/api/domain/article/dto/ArticleResponseDtoV2.java
+++ b/backend/src/main/java/io/linkloud/api/domain/article/dto/ArticleResponseDtoV2.java
@@ -176,6 +176,7 @@ public class ArticleResponseDtoV2 {
     @Getter
     public static class MemberArticlesByCondition implements HasId{
         private final Long id;
+        private boolean isAuthor;
         private final String title;
         private final String url;
         private final String description;
@@ -183,6 +184,10 @@ public class ArticleResponseDtoV2 {
         private final Integer hearts;
         private final String readStatus;
         private final List<TagDto.ArticleTagsResponse> tags;
+
+        public void setAuthor() {
+            this.isAuthor = true;
+        }
         @Override
         public Long getId() {
             return this.id;

--- a/backend/src/main/java/io/linkloud/api/domain/article/service/ArticleServiceV2Impl.java
+++ b/backend/src/main/java/io/linkloud/api/domain/article/service/ArticleServiceV2Impl.java
@@ -139,7 +139,22 @@ public class ArticleServiceV2Impl implements ArticleServiceV2{
         memberService.validateMember(memberId, loginMemberId);
         ReadStatus readStatus = ReadStatus.fromString(sortBy);
         SortBy titleOrLatest = SortBy.fromString(sortBy);
-        return articleRepository.MemberArticlesByCondition(memberId, titleOrLatest,readStatus, lastArticleId, pageable);
+
+        List<Long> myArticleIds = findMyArticleIds(loginMemberId);
+
+        Slice<MemberArticlesByCondition> memberArticlesByConditions = articleRepository.MemberArticlesByCondition(
+            memberId, titleOrLatest, readStatus, lastArticleId, pageable);
+        log.info("memberId={} created articles size={}",loginMemberId,myArticleIds.size());
+        // 내 북마크(최신순,상태순) 게시글들중에
+        // 내가 작성한 게시글 즉 dto.getId() == myArticle.getId() 이면
+        // 내가 작성한 글이므로 isAuthor == true
+        for (MemberArticlesByCondition dto : memberArticlesByConditions) {
+            if (myArticleIds.contains(dto.getId())) {
+                dto.setAuthor();
+            }
+        }
+
+        return memberArticlesByConditions;
     }
 
 


### PR DESCRIPTION
## ✏️ 요약

- **GET | /api/v2/member/{memberId}/articles**
    - author : 게시글 작성자 여부

---

- 1번 사용자가 2번 사용자의 게시글을 상태변환해서 조회할 경우
<img width="312" alt="image" src="https://github.com/linkloud/linkloud.io/assets/55350901/1b55fc56-a149-4417-b861-69d51052e5d9">


---

- 1번 사용자가 자기가 작성한 게시글을 상태변환해서 조회할 경우
<img width="265" alt="image" src="https://github.com/linkloud/linkloud.io/assets/55350901/531fa29c-9de1-4d03-ae2b-407ece4e1f4f">

- 통합 결과
<img width="502" alt="image" src="https://github.com/linkloud/linkloud.io/assets/55350901/4b22594b-616b-4234-ad73-6fbf49fb62bc">


## ✨ 변경 사항

(변경 사항 작성)

## 🏷️ 관련 이슈

(관련 이슈 번호 작성)

## 체크리스트

- [ ] 변경 사항이 테스트 되었는가?
- [ ] 코드 리뷰를 요청했는가?
